### PR TITLE
Replace the 'US' and '$' symbols in the price

### DIFF
--- a/scrapper.py
+++ b/scrapper.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
         # Checking price for used items from Amazon Warehouse
         try:
             warehouse_price = round(float(soup.select('#olpLinkWidget_feature_div .a-color-base')
-                                          [0].get_text()[:6].replace(',', '.'))*1.033616, 2)
+                                          [0].get_text()[:6].replace('$','').replace('US','').replace(',', '.'))*1.033616, 2)
         except IndexError:
             # If product doesn't have its price
             continue


### PR DESCRIPTION
When the script gets the price and attempts to convert to float the following exception occurs:

Traceback (most recent call last):
  File "C:\Users\rpiston\Desktop\Proyectos\Python\Amazon-Warehouse-Scrapper-master\scrapper.py", line 49, in <module>
    print(round(float(soup.select('#olpLinkWidget_feature_div .a-color-base')
ValueError: could not convert string to float: '$368.9'